### PR TITLE
Add some debug log and fix the recordCnt

### DIFF
--- a/src/main/java/org/apache/pulsar/ecosystem/io/SinkConnector.java
+++ b/src/main/java/org/apache/pulsar/ecosystem/io/SinkConnector.java
@@ -71,6 +71,11 @@ public class SinkConnector implements Sink<GenericObject> {
 
     @Override
     public void write(Record<GenericObject> record) throws Exception {
+        if (log.isDebugEnabled()) {
+            record.getMessage().ifPresent(m -> {
+                log.debug("Received message: {}", m.getMessageId());
+            });
+        }
         while (!messages.offer(new PulsarSinkRecord(record), 1, TimeUnit.SECONDS)) {
             if (!writer.isRunning()) {
                 String err = "Exit caused by lakehouse writer stop working";

--- a/src/main/java/org/apache/pulsar/ecosystem/io/SinkConnectorConfig.java
+++ b/src/main/java/org/apache/pulsar/ecosystem/io/SinkConnectorConfig.java
@@ -113,7 +113,8 @@ public abstract class SinkConnectorConfig implements Serializable {
                 return jsonMapper().readValue(new ObjectMapper().writeValueAsString(map),
                     DeltaSinkConnectorConfig.class);
             case HUDI_SINK:
-                return new DefaultSinkConnectorConfig();
+                return jsonMapper().readValue(new ObjectMapper().writeValueAsString(map),
+                    DefaultSinkConnectorConfig.class);
             default:
                 throw new IncorrectParameterException("Unexpected type. Only supports 'iceberg', 'delta', and 'hudi', "
                     + "but got " + type);

--- a/src/main/java/org/apache/pulsar/ecosystem/io/sink/SinkWriter.java
+++ b/src/main/java/org/apache/pulsar/ecosystem/io/sink/SinkWriter.java
@@ -78,6 +78,12 @@ public class SinkWriter implements Runnable {
                     continue;
                 }
 
+                if (log.isDebugEnabled()) {
+                    pulsarSinkRecord.getRecord().getMessage().ifPresent(m -> {
+                        log.debug("Handling message: {}", m.getMessageId());
+                    });
+                }
+
                 String schemaStr = pulsarSinkRecord.getSchema();
                 if (Strings.isNullOrEmpty(schemaStr.trim())) {
                     log.error("Failed to get schema from record, skip the record");
@@ -101,7 +107,11 @@ public class SinkWriter implements Runnable {
                 if (avroRecord.isPresent()) {
                     getOrCreateWriter().writeAvroRecord(avroRecord.get());
                     lastRecord = pulsarSinkRecord;
+                    recordsCnt++;
                     if (needCommit()) {
+                        if (log.isDebugEnabled()) {
+                            log.debug("Commit ");
+                        }
                         if (getOrCreateWriter().flush()) {
                             resetStatus();
                             commitFailedCnt = 0;

--- a/src/main/java/org/apache/pulsar/ecosystem/io/sink/hudi/BufferedConnectWriter.java
+++ b/src/main/java/org/apache/pulsar/ecosystem/io/sink/hudi/BufferedConnectWriter.java
@@ -100,6 +100,10 @@ public class BufferedConnectWriter {
         }
     }
 
+    public HoodieWriteConfig getConfig() {
+        return config;
+    }
+
     public void close() throws HoodieConnectorException {
         flushRecords();
         writeClient.close();


### PR DESCRIPTION
---

*Motivation*

The recordCnt is used to control commit action. When we
write a record successfully, the recordCnt should be increased.

The sink configuration for hudi can not return an default class,
that will cause the config validation failed. We need to use
jsonMapper to parse it then the type will be load.

*Modifications*

- add more debug info
- fix some issues when running the hudi sink

