### PR TITLE
Fix last batch does not trigger commit

### DIFF
--- a/src/main/java/org/apache/pulsar/ecosystem/io/sink/SinkWriter.java
+++ b/src/main/java/org/apache/pulsar/ecosystem/io/sink/SinkWriter.java
@@ -160,7 +160,7 @@ public class SinkWriter implements Runnable {
     }
 
     private boolean needCommit() {
-        return System.currentTimeMillis() - lastCommitTime > timeIntervalPerCommit
+        return System.currentTimeMillis() - lastCommitTime >= timeIntervalPerCommit
             || recordsCnt >= maxRecordsPerCommit;
     }
 


### PR DESCRIPTION
When the last batch messages written into lakehouse and doesn't trigger commit, and then there is no new messages, it won't trigger commit check.