### PR TITLE
Add retry logic for delta schema update

### DIFF
--- a/src/main/java/org/apache/pulsar/ecosystem/io/sink/delta/DeltaWriter.java
+++ b/src/main/java/org/apache/pulsar/ecosystem/io/sink/delta/DeltaWriter.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Random;
 import java.util.UUID;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
@@ -62,6 +63,7 @@ public class DeltaWriter implements LakehouseWriter {
     private DeltaLog deltaLog;
     private final Schema schema;
     private DeltaParquetWriter writer;
+    private Random random;
 
     public DeltaWriter(SinkConnectorConfig cfg, Schema schema) {
         this.config = (DeltaSinkConnectorConfig) cfg;
@@ -70,6 +72,7 @@ public class DeltaWriter implements LakehouseWriter {
 
         Configuration configuration = new Configuration();
         deltaLog = DeltaLog.forTable(configuration, config.tablePath);
+        random = new Random(42);
 
         if (!deltaLog.tableExists()) {
             createTable(schema, config.getPartitionColumns());
@@ -136,16 +139,34 @@ public class DeltaWriter implements LakehouseWriter {
         commitFiles(writer.closeAndFlush());
 
         // update delta table schema
-        OptimisticTransaction optimisticTransaction = deltaLog.startTransaction();
-        StructType structType = SchemaConverter.convertAvroSchemaToDeltaSchema(schema);
-        Metadata metadata =  optimisticTransaction.metadata().copyBuilder().schema(structType).build();
-        optimisticTransaction.updateMetadata(metadata);
-        List<Action> filesToCommit = new ArrayList<>();
-        optimisticTransaction.commit(filesToCommit, new Operation(Operation.Name.UPGRADE_SCHEMA), COMMIT_INFO);
+        int cnt = 0;
+        while (true) {
+            try {
+                cnt++;
+                OptimisticTransaction optimisticTransaction = deltaLog.startTransaction();
+                StructType structType = SchemaConverter.convertAvroSchemaToDeltaSchema(schema);
+                Metadata metadata = optimisticTransaction.metadata().copyBuilder().schema(structType).build();
+                optimisticTransaction.updateMetadata(metadata);
+                List<Action> filesToCommit = new ArrayList<>();
+                optimisticTransaction.commit(filesToCommit, new Operation(Operation.Name.UPGRADE_SCHEMA), COMMIT_INFO);
+                log.info("update delta schema succeed. {}",
+                    metadata.getSchema() != null ? metadata.getSchema().getTreeString() : null);
+                break;
+            } catch (Exception e) {
+                if (cnt >= 5) {
+                    log.error("Failed to update delta schema. ", e);
+                    throw e;
+                }
+
+                try {
+                    Thread.sleep(random.nextInt(1000));
+                } catch (InterruptedException ex) {
+                    //
+                }
+            }
+        }
 
         writer.updateSchema(schema);
-        log.info("update delta schema succeed. {}",
-            metadata.getSchema() != null ? metadata.getSchema().getTreeString() : null);
         return true;
     }
 


### PR DESCRIPTION
### Motivation
When we use multiple delta sink connector instance and the schema updated, multi delta sink connector instance will concurrently update the delta table schema, leading to throw the following exception
```
2022-05-13T15:03:56,995+0800 [lakehouse-io-1-1] ERROR org.apache.pulsar.ecosystem.io.sink.SinkWriter - process record failed.
io.delta.standalone.exceptions.MetadataChangedException: The metadata of the Delta table has been changed by a concurrent update. Please try the operation again.
Conflicting commit: {"timestamp":1652425436731,"operation":"UPDATE SCHEMA","operationParameters":{},"readVersion":3,"isolationLevel":"SnapshotIsolation","isBlindAppend":true,"operationMetrics":{},"engineInfo":"pulsar-sink-
connector-version-2.9.1 Delta-Standalone/0.3.0"}
Refer to https://docs.delta.io/latest/concurrency-control.html for more details.
        at io.delta.standalone.internal.exception.DeltaErrors$.metadataChangedException(DeltaErrors.scala:210) ~[delta-standalone_2.12-0.3.0.jar:0.3.0]
        at io.delta.standalone.internal.ConflictChecker.checkNoMetadataUpdates(ConflictChecker.scala:140) ~[delta-standalone_2.12-0.3.0.jar:0.3.0]
        at io.delta.standalone.internal.ConflictChecker.checkConflicts(ConflictChecker.scala:90) ~[delta-standalone_2.12-0.3.0.jar:0.3.0]
        at io.delta.standalone.internal.OptimisticTransactionImpl.$anonfun$checkForConflicts$3(OptimisticTransactionImpl.scala:434) ~[delta-standalone_2.12-0.3.0.jar:0.3.0]
        at scala.runtime.java8.JFunction1$mcVJ$sp.apply(JFunction1$mcVJ$sp.java:23) ~[scala-library-2.12.8.jar:?]
        at scala.collection.immutable.NumericRange.foreach(NumericRange.scala:74) ~[scala-library-2.12.8.jar:?]
        at io.delta.standalone.internal.OptimisticTransactionImpl.checkForConflicts(OptimisticTransactionImpl.scala:427) ~[delta-standalone_2.12-0.3.0.jar:0.3.0]
        at io.delta.standalone.internal.OptimisticTransactionImpl.$anonfun$doCommitRetryIteratively$1(OptimisticTransactionImpl.scala:322) ~[delta-standalone_2.12-0.3.0.jar:0.3.0]
        at scala.runtime.java8.JFunction0$mcJ$sp.apply(JFunction0$mcJ$sp.java:23) ~[scala-library-2.12.8.jar:?]
        at io.delta.standalone.internal.DeltaLogImpl.lockInterruptibly(DeltaLogImpl.scala:155) ~[delta-standalone_2.12-0.3.0.jar:0.3.0]
        at io.delta.standalone.internal.OptimisticTransactionImpl.doCommitRetryIteratively(OptimisticTransactionImpl.scala:304) ~[delta-standalone_2.12-0.3.0.jar:0.3.0]
        at io.delta.standalone.internal.OptimisticTransactionImpl.commit(OptimisticTransactionImpl.scala:153) ~[delta-standalone_2.12-0.3.0.jar:0.3.0]
        at org.apache.pulsar.ecosystem.io.sink.delta.DeltaWriter.updateSchema(DeltaWriter.java:144) ~[m_1ITQEHoBTr7VpGZzX4Dg/:?]
        at org.apache.pulsar.ecosystem.io.sink.SinkWriter.run(SinkWriter.java:104) [m_1ITQEHoBTr7VpGZzX4Dg/:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [netty-common-4.1.77.Final.jar:4.1.77.Final]
        at java.lang.Thread.run(Thread.java:834) [?:?]
```

The delta table schema doesn't support field deletion.
https://github.com/delta-io/connectors/blob/925bd79bcae9b0c85e7cd7342e4686e7be2a21d5/standalone/src/main/java/io/delta/standalone/types/StructType.java#L204-L222

### Modification
Add retry logic for delta schema update.