### PR TITLE
Fail the CI when the test is failed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <redirectTestOutputToFile>true</redirectTestOutputToFile>
     <spotbugs-annotations.version>3.1.8</spotbugs-annotations.version>
-    <testRetryCount>2</testRetryCount>
+    <testRetryCount>0</testRetryCount>
 
     <!-- connector dependencies -->
     <jackson.version>2.13.2.1</jackson.version>


### PR DESCRIPTION
---

Fixes #36

*Motivation*

I found the CI won't fail when there has test failure.
We have settings `testRetryCount` as 2, and that will
make the failure tests as flaky and won't fail the CI.

https://maven.apache.org/surefire/maven-surefire-plugin/examples/rerun-failing-tests.html

*Modifications*

Change the `testRetryCount` to 0 to make it fail fast

