### PR TITLE
upgrade hadoop version to 3.3.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <pulsar.version>2.10.0.4</pulsar.version>
     <log4j2.version>2.17.2</log4j2.version>
     <slf4j.version>1.7.25</slf4j.version>
-    <hadoop.version>3.2.2</hadoop.version>
+    <hadoop.version>3.3.3</hadoop.version>
     <iceberg.version>0.13.1</iceberg.version>
     <parquet.version>1.12.0</parquet.version>
     <hudi.version>0.11.0</hudi.version>
@@ -419,6 +419,10 @@
           <groupId>io.dropwizard.metrics</groupId>
           <artifactId>*</artifactId>
         </exclusion>
+        <exclusion>
+          <artifactId>log4j</artifactId>
+          <groupId>log4j</groupId>
+        </exclusion>
       </exclusions>
     </dependency>
 
@@ -426,6 +430,12 @@
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-framework</artifactId>
       <version>${curator.version}</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>log4j</artifactId>
+          <groupId>log4j</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Upgrade Hadoop dependency to 3.3.3 to resolve some CVEs
[CVE-2020-27216](https://www.cve.org/CVERecord?id=CVE-2020-27216)
[CVE-2022-25168](https://www.cve.org/CVERecord?id=CVE-2022-25168)
[CVE-2022-26612](https://www.cve.org/CVERecord?id=CVE-2022-26612)