### PR TITLE
Fix CVEs introduced by hadoop-common

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -346,6 +346,18 @@
           <groupId>com.sun.jersey</groupId>
           <artifactId>*</artifactId>
         </exclusion>
+        <exclusion>
+          <artifactId>jetty-servlet</artifactId>
+          <groupId>org.eclipse.jetty</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>jetty-util</artifactId>
+          <groupId>org.eclipse.jetty</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>jetty-webapp</artifactId>
+          <groupId>org.eclipse.jetty</groupId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -37,8 +37,8 @@
   <description>It is a lakehouse connector streaming convert data between lakehouse and Apache Pulsar.</description>
 
   <properties>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>8</maven.compiler.source>
+    <maven.compiler.target>8</maven.compiler.target>
     <java.version>17</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -52,10 +52,10 @@
     <pulsar.version>2.10.0.4</pulsar.version>
     <log4j2.version>2.17.2</log4j2.version>
     <slf4j.version>1.7.25</slf4j.version>
-    <hadoop.version>3.2.2</hadoop.version>
+    <hadoop.version>3.2.4</hadoop.version>
     <iceberg.version>0.13.1</iceberg.version>
     <parquet.version>1.12.0</parquet.version>
-    <hudi.version>0.11.0</hudi.version>
+    <hudi.version>0.12.2</hudi.version>
     <delta.version>0.3.0</delta.version>
     <parquet.avro.version>1.12.2</parquet.avro.version>
     <netty.version>4.1.77.Final</netty.version>

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,40 @@
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-client</artifactId>
         <version>${hadoop.version}</version>
+        <exclusions>
+          <exclusion>
+            <artifactId>commons-logging</artifactId>
+            <groupId>commons-logging</groupId>
+          </exclusion>
+          <exclusion>
+            <artifactId>log4j</artifactId>
+            <groupId>log4j</groupId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-yarn-*</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-mapreduce-*</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.sun.jersey</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+          <exclusion>
+            <artifactId>jetty-servlet</artifactId>
+            <groupId>org.eclipse.jetty</groupId>
+          </exclusion>
+          <exclusion>
+            <artifactId>jetty-util</artifactId>
+            <groupId>org.eclipse.jetty</groupId>
+          </exclusion>
+          <exclusion>
+            <artifactId>jetty-webapp</artifactId>
+            <groupId>org.eclipse.jetty</groupId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
@@ -258,6 +292,16 @@
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-azure</artifactId>
         <version>${hadoop.version}</version>
+        <exclusions>
+          <exclusion>
+            <artifactId>jetty-util</artifactId>
+            <groupId>org.eclipse.jetty</groupId>
+          </exclusion>
+          <exclusion>
+            <artifactId>jetty-util-ajax</artifactId>
+            <groupId>org.eclipse.jetty</groupId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <!-- Cloud dependencies end -->
@@ -325,40 +369,6 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client</artifactId>
-      <exclusions>
-        <exclusion>
-          <artifactId>commons-logging</artifactId>
-          <groupId>commons-logging</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>log4j</artifactId>
-          <groupId>log4j</groupId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-yarn-*</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-mapreduce-*</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.sun.jersey</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-        <exclusion>
-          <artifactId>jetty-servlet</artifactId>
-          <groupId>org.eclipse.jetty</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>jetty-util</artifactId>
-          <groupId>org.eclipse.jetty</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>jetty-webapp</artifactId>
-          <groupId>org.eclipse.jetty</groupId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>
@@ -505,7 +515,6 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
 
   <profiles>

--- a/src/main/java/org/apache/pulsar/ecosystem/io/lakehouse/sink/hudi/HoodieWriterProvider.java
+++ b/src/main/java/org/apache/pulsar/ecosystem/io/lakehouse/sink/hudi/HoodieWriterProvider.java
@@ -68,8 +68,6 @@ public class HoodieWriterProvider {
             .withAutoCommit(false)
             .withIndexConfig(HoodieIndexConfig.newBuilder().withIndexType(HoodieIndex.IndexType.INMEMORY).build())
             .withCompactionConfig(HoodieCompactionConfig.newBuilder()
-                .withAutoArchive(false)
-                .withAutoClean(false)
                 .withInlineCompaction(false).build())
             .withClusteringConfig(HoodieClusteringConfig.newBuilder()
                 .withInlineClustering(false).build());


### PR DESCRIPTION
### Motivation
Fix CVEs introduced by `hadoop-common` and `hudi-client-common`. 
The detailed information can be found:
https://app.snyk.io/org/streamnative-org/project/f978ac35-47fe-463f-82a9-11e997ddf8d7

```
log4j:log4j
Introduced through: org.apache.pulsar.ecosystem:pulsar-io-lakehouse@2.11.0-SNAPSHOT › org.apache.hudi:hudi-java-client@0.11.0 › org.apache.hudi:hudi-client-common@0.11.0 › log4j:log4j@1.2.17

com.fasterxml.woodstox:woodstox-core
Introduced through: org.apache.pulsar.ecosystem:pulsar-io-lakehouse@2.11.0-SNAPSHOT › org.apache.hadoop:hadoop-client@3.2.2 › org.apache.hadoop:hadoop-common@3.2.2 › com.fasterxml.woodstox:woodstox-core@5.0.3

org.apache.hadoop:hadoop-common
ntroduced through: org.apache.pulsar.ecosystem:pulsar-io-lakehouse@2.11.0-SNAPSHOT › org.apache.hadoop:hadoop-client@3.2.2 › org.apache.hadoop:hadoop-common@3.2.2
Fix: [Upgrade](https://app.snyk.io/org/streamnative-org/fix/f978ac35-47fe-463f-82a9-11e997ddf8d7?vuln=SNYK-JAVA-ORGAPACHEHADOOP-2443177) to org.apache.hadoop:hadoop-client@3.2.3

org.apache.hadoop:hadoop-common
Introduced through: org.apache.pulsar.ecosystem:pulsar-io-lakehouse@2.11.0-SNAPSHOT › org.apache.hadoop:hadoop-client@3.2.2 › org.apache.hadoop:hadoop-common@3.2.2
Fix: [Upgrade](https://app.snyk.io/org/streamnative-org/fix/f978ac35-47fe-463f-82a9-11e997ddf8d7?vuln=SNYK-JAVA-ORGAPACHEHADOOP-2975400) to org.apache.hadoop:hadoop-client@3.2.4
```

### Modifications
- Upgrade hadoop-common version from `3.2.2` to `3.2.4`
- Upgrade hudi version from `0.11.0` to `0.12.2`