### PR TITLE
Make unit tests can run with JDK8

### DIFF
--- a/.github/workflows/pr-unit-tests-jdk17.yml
+++ b/.github/workflows/pr-unit-tests-jdk17.yml
@@ -1,4 +1,4 @@
-name: lakehouse mvn build check and unit tests
+name: lakehouse unit tests (JDK17)
 
 on:
   pull_request:

--- a/.github/workflows/pr-unit-tests-jdk8.yml
+++ b/.github/workflows/pr-unit-tests-jdk8.yml
@@ -23,7 +23,7 @@ jobs:
         if: ${{ needs.changed_files_job.outputs.docs_only != 'true' }}
         with:
           distribution: 'temurin'
-          java-version: 1.8
+          java-version: 8
 
       - name: License check
         run: mvn -ntp -B license:check

--- a/.github/workflows/pr-unit-tests-jdk8.yml
+++ b/.github/workflows/pr-unit-tests-jdk8.yml
@@ -1,0 +1,62 @@
+name: lakehouse unit tests (JDK8)
+
+on:
+  pull_request:
+    branches:
+      - master
+      - branch-*
+  push:
+    branches:
+      - master
+      - branch-*
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        if: ${{ needs.changed_files_job.outputs.docs_only != 'true' }}
+        with:
+          distribution: 'temurin'
+          java-version: 1.8
+
+      - name: License check
+        run: mvn -ntp -B license:check
+
+      - name: Build cloud package with Maven skipTests
+        run: mvn clean install -ntp -B -DskipTests -P cloud
+
+      - name: Build with Maven skipTests
+        run: mvn clean install -ntp -B -DskipTests
+
+      - name: Style check
+        run: mvn -ntp -B checkstyle:check
+
+      - name: Spotbugs check
+        run: mvn -ntp -B spotbugs:check
+
+      - name: unit test after build
+        env:
+          CLOUD_BUCKET_NAME: ${{ secrets.CLOUD_BUCKET_NAME }}
+          AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        run: mvn test -Pcloud
+
+      - name: package surefire artifacts
+        if: failure()
+        run: |
+          rm -rf artifacts
+          mkdir artifacts
+          find . -type d -name "*surefire*" -exec cp --parents -R {} artifacts/ \;
+          zip -r artifacts.zip artifacts
+      - uses: actions/upload-artifact@master
+        name: upload surefire-artifacts
+        if: failure()
+        with:
+          name: surefire-artifacts
+          path: artifacts.zip

--- a/pom.xml
+++ b/pom.xml
@@ -37,8 +37,8 @@
   <description>It is a lakehouse connector streaming convert data between lakehouse and Apache Pulsar.</description>
 
   <properties>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>8</maven.compiler.source>
+    <maven.compiler.target>8</maven.compiler.target>
     <java.version>17</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -77,6 +77,7 @@
     <puppycrawl.checkstyle.version>8.37</puppycrawl.checkstyle.version>
     <spotbugs-maven-plugin.version>4.2.2</spotbugs-maven-plugin.version>
     <cloudPkgSuffix></cloudPkgSuffix>
+    <test.additional.args />
   </properties>
 
   <licenses>
@@ -532,6 +533,36 @@
         </dependency>
       </dependencies>
     </profile>
+    <profile>
+      <id>jdk11</id>
+      <activation>
+        <jdk>[11,)</jdk>
+      </activation>
+      <properties>
+        <maven.compiler.release>${maven.compiler.target}</maven.compiler.release>
+        <test.additional.args>
+          --add-opens java.base/java.io=ALL-UNNAMED
+          --add-opens java.base/java.lang=ALL-UNNAMED
+          --add-opens java.base/java.lang.reflect=ALL-UNNAMED
+          --add-opens java.base/java.lang.invoke=ALL-UNNAMED
+          --add-opens java.base/java.net=ALL-UNNAMED
+          --add-opens java.base/java.nio=ALL-UNNAMED
+          --add-opens java.base/java.nio.channels.spi=ALL-UNNAMED
+          --add-opens java.base/java.nio.file=ALL-UNNAMED
+          --add-opens java.base/java.util=ALL-UNNAMED
+          --add-opens java.base/java.util.concurrent=ALL-UNNAMED
+          --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED
+          --add-opens java.base/java.util.stream=ALL-UNNAMED
+          --add-opens java.base/java.util.zip=ALL-UNNAMED
+          --add-opens java.base/java.time=ALL-UNNAMED
+          --add-opens java.base/jdk.internal.loader=ALL-UNNAMED
+          --add-opens java.base/sun.net.dns=ALL-UNNAMED
+          --add-opens java.base/sun.nio.ch=ALL-UNNAMED
+          --add-opens java.base/sun.security.jca=ALL-UNNAMED
+          --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED
+        </test.additional.args>
+      </properties>
+    </profile>
   </profiles>
 
   <build>
@@ -561,12 +592,7 @@
             <reuseForks>false</reuseForks>
             <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
             <rerunFailingTestsCount>${testRetryCount}</rerunFailingTestsCount>
-            <argLine>
-              --add-opens java.base/java.util=ALL-UNNAMED
-              --add-opens java.base/java.lang=ALL-UNNAMED
-              --add-opens java.base/java.util.concurrent=ALL-UNNAMED
-              --add-opens java.base/java.nio=ALL-UNNAMED
-            </argLine>
+            <argLine> -Xmx2G ${test.additional.args}</argLine>
           </configuration>
         </plugin>
         <!-- package -->


### PR DESCRIPTION
### Motivation
1. When I run unit tests with JDK8, it failed.
2. The CI only includes JDK17, we need to ensure the code can run well under JDK8

### Modifications
1. Add argLine for tests to ensure all the tests can run well under JDK8
2. Add a new CI for running unit tests under JDK8