### PR TITLE
Update snappy dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -250,6 +250,12 @@
         <version>${slf4j.version}</version>
       </dependency>
 
+      <dependency>
+        <groupId>org.xerial.snappy</groupId>
+        <artifactId>snappy-java</artifactId>
+        <version>1.1.8.4</version>
+      </dependency>
+
       <!--  Hoodie dependencies begin   -->
       <dependency>
         <groupId>org.apache.hudi</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
     <aws.sdk.version>1.12.220</aws.sdk.version>
     <gcs.version>hadoop3-2.2.1</gcs.version>
     <curator.version>2.12.0</curator.version>
+    <snappy.java.version>1.1.8.4</snappy.java.version>
 
     <!-- test dependencies -->
     <testng.version>7.3.0</testng.version>
@@ -253,7 +254,7 @@
       <dependency>
         <groupId>org.xerial.snappy</groupId>
         <artifactId>snappy-java</artifactId>
-        <version>1.1.8.4</version>
+        <version>${snappy.java.version}</version>
       </dependency>
 
       <!--  Hoodie dependencies begin   -->
@@ -433,6 +434,11 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.xerial.snappy</groupId>
+      <artifactId>snappy-java</artifactId>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/apache/pulsar/ecosystem/io/lakehouse/sink/SinkWriter.java
+++ b/src/main/java/org/apache/pulsar/ecosystem/io/lakehouse/sink/SinkWriter.java
@@ -113,8 +113,8 @@ public class SinkWriter implements Runnable {
                     recordsCnt++;
                     commitIfNeed();
                 }
-            } catch (Exception e) {
-                log.error("process record failed. ", e);
+            } catch (Throwable throwable) {
+                log.error("process record failed. ", throwable);
                 // fail the sink connector.
                 running = false;
             }


### PR DESCRIPTION
Fixes #444 

### Motivation

Solve dependency issue to allow Lakehouse Sink Connector to write to local delta tables.

### Modifications

Added a snappy dependency to work with M1 Macbook and changed `exception` to `throwable` in SinkWriter.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

