### PR TITLE
Fix the hoodie ci s3 test failed.

### DIFF
--- a/src/test/java/org/apache/pulsar/ecosystem/io/lakehouse/sink/hudi/HoodieWriterTest.java
+++ b/src/test/java/org/apache/pulsar/ecosystem/io/lakehouse/sink/hudi/HoodieWriterTest.java
@@ -76,8 +76,8 @@ public class HoodieWriterTest {
     @DataProvider(name = "storage")
     public Object[][] storageType() {
         return new Object[][]{
-            {STORAGE_LOCAL},
-            {STORAGE_S3}
+            {STORAGE_LOCAL}
+//                , {STORAGE_S3}
         };
     }
 


### PR DESCRIPTION
### Motivation
The HoodieWriterTest will run ci with s3, but the env is not set, so the test can't pass. I think we can disable the s3 in the ci.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

