### PR TITLE
Support multi-arch connector image release

### DIFF
--- a/.github/workflows/release-by-workflow.yml
+++ b/.github/workflows/release-by-workflow.yml
@@ -27,6 +27,12 @@ jobs:
       - name: Login streamnative docker hub
         run: docker login -u="${{ secrets.DOCKER_USER }}" -p="${{ secrets.DOCKER_PASSWORD }}"
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - uses: robinraju/release-downloader@v1.10
         with:
           tag: v${{ inputs.version }}
@@ -41,11 +47,17 @@ jobs:
         with:
           max_attempts: 99
           retry_wait_seconds: 60
-          timeout_minutes: 5
+          timeout_minutes: 30
           command: |
             mkdir -p target
             mv pulsar-io-lakehouse-*.nar target
             REPO=`mvn -q -Dexec.executable=echo -Dexec.args='${project.artifactId}' --non-recursive exec:exec 2>/dev/null`
             IMAGE_REPO=streamnative/${REPO}
-            docker build --build-arg PULSAR_VERSION="$PULSAR_VERSION" --build-arg SNAPPY_VERSION="$SNAPPY_VERSION" -t ${IMAGE_REPO}:${CONNECTOR_VERSION} -f ./image/Dockerfile ./
-            docker push ${IMAGE_REPO}:${CONNECTOR_VERSION}
+            docker buildx build \
+              --platform linux/amd64,linux/arm64 \
+              --build-arg PULSAR_VERSION="$PULSAR_VERSION" \
+              --build-arg SNAPPY_VERSION="$SNAPPY_VERSION" \
+              -t ${IMAGE_REPO}:${CONNECTOR_VERSION} \
+              -f ./image/Dockerfile \
+              --push \
+              ./

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,12 @@ jobs:
       - name: Login streamnative docker hub
         run: docker login -u="${{ secrets.DOCKER_USER }}" -p="${{ secrets.DOCKER_PASSWORD }}"
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Set project version
         run: |
           project_version=${GITHUB_REF#refs/tags/v}
@@ -40,12 +46,18 @@ jobs:
         with:
           max_attempts: 99
           retry_wait_seconds: 60
-          timeout_minutes: 5
+          timeout_minutes: 30
           command: |
             CONNECTOR_VERSION=`./scripts/get-version.sh`
             PULSAR_VERSION=`mvn -q -Dexec.executable=echo -Dexec.args='${pulsar.version}' --non-recursive exec:exec 2>/dev/null`
             SNAPPY_VERSION=`mvn help:evaluate -Dexpression=snappy.java.version -q -DforceStdout`
             REPO=`mvn -q -Dexec.executable=echo -Dexec.args='${project.artifactId}' --non-recursive exec:exec 2>/dev/null`
             IMAGE_REPO=streamnative/${REPO}
-            docker build --build-arg PULSAR_VERSION="$PULSAR_VERSION" --build-arg SNAPPY_VERSION="$SNAPPY_VERSION" -t ${IMAGE_REPO}:${CONNECTOR_VERSION} -f ./image/Dockerfile ./
-            docker push ${IMAGE_REPO}:${CONNECTOR_VERSION}
+            docker buildx build \
+              --platform linux/amd64,linux/arm64 \
+              --build-arg PULSAR_VERSION="$PULSAR_VERSION" \
+              --build-arg SNAPPY_VERSION="$SNAPPY_VERSION" \
+              -t ${IMAGE_REPO}:${CONNECTOR_VERSION} \
+              -f ./image/Dockerfile \
+              --push \
+              ./

--- a/pom.xml
+++ b/pom.xml
@@ -47,22 +47,22 @@
     <testRetryCount>0</testRetryCount>
 
     <!-- connector dependencies -->
-    <jackson.version>2.13.2.1</jackson.version>
-    <lombok.version>1.18.22</lombok.version>
-    <pulsar.version>4.0.1.4</pulsar.version>
+    <jackson.version>2.18.6</jackson.version>
+    <lombok.version>1.18.42</lombok.version>
+    <pulsar.version>4.2.0.6</pulsar.version>
     <log4j2.version>2.17.2</log4j2.version>
-    <slf4j.version>1.7.25</slf4j.version>
+    <slf4j.version>2.0.17</slf4j.version>
     <hadoop.version>3.2.4</hadoop.version>
     <iceberg.version>0.13.1</iceberg.version>
     <parquet.version>1.12.0</parquet.version>
     <hudi.version>0.12.2</hudi.version>
     <delta.version>0.3.0</delta.version>
     <parquet.avro.version>1.12.2</parquet.avro.version>
-    <netty.version>4.1.77.Final</netty.version>
-    <aws.sdk.version>1.12.220</aws.sdk.version>
+    <netty.version>4.1.133.Final</netty.version>
+    <aws.sdk.version>1.12.788</aws.sdk.version>
     <gcs.version>hadoop3-2.2.1</gcs.version>
     <curator.version>2.12.0</curator.version>
-    <snappy.java.version>1.1.8.4</snappy.java.version>
+    <snappy.java.version>1.1.10.8</snappy.java.version>
 
     <!-- test dependencies -->
     <testng.version>7.3.0</testng.version>
@@ -100,6 +100,21 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-core</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-annotations</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.datatype</groupId>
+        <artifactId>jackson-datatype-jsr310</artifactId>
         <version>${jackson.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
Fixes https://github.com/streamnative/product-roadmap/issues/1572

## Summary
- Upgrade the connector runtime to Pulsar `4.2.0.6` and align shared dependency versions with Pulsar `branch-4.2` where applicable.
- Update release image workflows to use Buildx/QEMU and publish `linux/amd64,linux/arm64` images.
- Keep existing test boundaries unchanged; this PR does not add Surefire test excludes or change unit-test workflow commands.

## Validation
- `mvn clean install -DskipTests`
- workflow YAML parse check
- `git diff --check`

Note: after keeping the original test boundaries, `mvn test -Dtest="*Test" -DfailIfNoTests=false` may reach existing external integration tests in some connectors and requires their normal external services, such as Docker/Testcontainers or LocalStack.